### PR TITLE
Update 20220928_jquantsapi_tutorial.ipynb

### DIFF
--- a/20220928_jquantsapi_tutorial.ipynb
+++ b/20220928_jquantsapi_tutorial.ipynb
@@ -781,7 +781,7 @@
     "# stock_fin = pd.read_csv(stock_fins_csvfile_path)\n",
     "# stock_fin[\"base_date\"] = pd.to_datetime(stock_fin[\"base_date\"])\n",
     "# stock_labels = pd.read_csv(stock_labels_csvfile_path)\n",
-    "# stock_labels[\"base_date\"] = pd.to_datetime(stock_fin[\"base_date\"])"
+    "# stock_labels[\"base_date\"] = pd.to_datetime(stock_labels[\"base_date\"])"
    ]
   },
   {


### PR DESCRIPTION
Fixed a possible typo in the notebook. 
The original code failed at 
### 目的変数の生成
#### Chapter 2.9.2
because the df stock_labels doesn't have the correct datetime as index.
