### PR TITLE
fix: update end_dt

### DIFF
--- a/20220915_jquantsapi_uki_predictor.ipynb
+++ b/20220915_jquantsapi_uki_predictor.ipynb
@@ -162,10 +162,8 @@
         "# J-Quants API から取得するデータの期間\n",
         "HISTORICAL_DATA_YEARS = 5\n",
         "DAYS_IN_YESR = 365 # FIXME\n",
-        "# start_dt: datetime = datetime(2017, 1, 1)\n",
         "start_dt: datetime = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=(HISTORICAL_DATA_YEARS*365))\n",
-        "# end_dt: datetime = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)\n",
-        "end_dt: datetime = datetime(2022, 5, 12)  # FIXME: 2022-05-13の財務情報取得に未対応\n",
+        "end_dt: datetime = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)\n",
         "start_dt_yyyymmdd = start_dt.strftime(\"%Y%m%d\")\n",
         "end_dt_yyyymmdd = end_dt.strftime(\"%Y%m%d\")\n",
         "\n",
@@ -185,15 +183,11 @@
         "# トレーニング・検証データ期間\n",
         "PURGING_DAYS = 31\n",
         "TRAIN_DATA_DAYS = (3 * 365) - PURGING_DAYS  # FIXME: データ期間から割合で決定する\n",
-        "# train_start_dt: datetime = datetime(2017, 1, 1)\n",
-        "# train_end_dt: datetime = datetime(2020,11,30)\n",
         "train_start_dt: datetime = start_dt\n",
         "train_end_dt: datetime = start_dt + timedelta(days=TRAIN_DATA_DAYS)\n",
         "\n",
         "# テスト・評価期間\n",
-        "# test_start_dt: datetime = datetime(2021, 1, 1)\n",
         "test_start_dt = train_end_dt + timedelta(days=PURGING_DAYS)\n",
-        "# test_end_dt: datetime = datetime(2022, 7, 31)\n",
         "\n",
         "# デバッグ中は短い期間でチェック・・・\n",
         "# train_start_dt: datetime = datetime(2022, 3, 1)\n",
@@ -1569,9 +1563,10 @@
   ],
   "metadata": {
     "colab": {
-      "provenance": [],
-      "machine_shape": "hm"
+      "machine_shape": "hm",
+      "provenance": []
     },
+    "gpuClass": "standard",
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",
@@ -1588,8 +1583,7 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython2",
       "version": "2.7.6"
-    },
-    "gpuClass": "standard"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
- jquants-api-client-python の pagination_key 対応がリリースされたためデータ取得時の end_dt を最新日付に変更しました
    - https://github.com/J-Quants/jquants-api-client-python/pull/76